### PR TITLE
Add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical Git and GitHub workflows, collaboration, and Copilot basics.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the in-memory activities list so students can register (addresses issue #6).

Change summary:
- Add new activity entry in `src/app.py` with description, schedule, max participants, and empty participants list.

This is a minimal fix to make the activity available quickly; should be followed by persistence and admin UI work per the backlog.